### PR TITLE
TT-709: Upgrade dropwizard to 1.1.4

### DIFF
--- a/common-utils/build.gradle
+++ b/common-utils/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     testCompile 'junit:junit:4.12',
             'org.assertj:assertj-core:1.7.1',
-            'org.mockito:mockito-core:1.10.17'
+            'org.mockito:mockito-core:2.7.6'
 
     compile 'com.google.guava:guava:19.0',
             'commons-codec:commons-codec:1.6',
@@ -10,5 +10,5 @@ dependencies {
             'joda-time:joda-time:2.7',
             'org.yaml:snakeyaml:1.12',
             'javax.validation:validation-api:1.1.0.Final',
-            'io.dropwizard:dropwizard-logging:1.0.9'
+            'io.dropwizard:dropwizard-logging:1.1.4'
 }

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -21,7 +21,7 @@ tput setaf 3
 printf "to update the following dependent projects:\n"
 
 printf "\n ida-hub"
-printf "\n ida-frontend"
+printf "\n verify-frontend-api"
 printf "\n ida-compliance-tool"
 printf "\n ida-sample-rp"
 printf "\n ida-stub-idp"

--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     testCompile "junit:junit:4.12",
             "org.assertj:assertj-core:1.7.1",
-            "org.mockito:mockito-core:1.10.17"
+            "org.mockito:mockito-core:2.7.6"
 
     def dependencyVersions = [
-            dropwizardVersion:"1.0.9"
+            dropwizardVersion:"1.1.4"
     ]
 
     compile "javax.inject:javax.inject:1",
@@ -12,6 +12,6 @@ dependencies {
             "io.dropwizard:dropwizard-core:$dependencyVersions.dropwizardVersion",
             "io.dropwizard:dropwizard-client:$dependencyVersions.dropwizardVersion",
             "javax.ws.rs:javax.ws.rs-api:2.0.1",
-            "uk.gov.ida:dropwizard-logstash:1.0.5-37",
+            "uk.gov.ida:dropwizard-logstash:1.1.4-49",
             "org.apache.commons:commons-lang3:3.3.2"
 }

--- a/rest-utils/src/test/java/uk/gov/ida/analytics/AnalyticsReporterTest.java
+++ b/rest-utils/src/test/java/uk/gov/ida/analytics/AnalyticsReporterTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.configuration.AnalyticsConfiguration;
 import uk.gov.ida.configuration.AnalyticsConfigurationBuilder;
 
@@ -46,9 +46,6 @@ import static uk.gov.ida.analytics.AnalyticsReporter.PIWIK_VISITOR_ID;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AnalyticsReporterTest {
-
-    @Mock
-    private Client client;
 
     @Mock
     private ContainerRequest requestContext;
@@ -86,8 +83,6 @@ public class AnalyticsReporterTest {
     public void shouldCallGenerateUrlAndSendToPiwkAsynchronously() throws MalformedURLException, URISyntaxException {
         String friendlyDescription = "friendly description of URL";
         URI piwikUri = URI.create("piwik");
-
-        when(requestContext.getHeaderString("User-Agent")).thenReturn("Chrome");
 
         AnalyticsReporter analyticsReporter = spy(new AnalyticsReporter(piwikClient, new AnalyticsConfigurationBuilder().build()));
 

--- a/rest-utils/src/test/java/uk/gov/ida/jerseyclient/JsonClientTest.java
+++ b/rest-utils/src/test/java/uk/gov/ida/jerseyclient/JsonClientTest.java
@@ -4,22 +4,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.ida.common.ExceptionType;
-import uk.gov.ida.exceptions.ApplicationException;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
+import org.mockito.junit.MockitoJUnitRunner;
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
-import java.util.UUID;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -28,13 +17,7 @@ public class JsonClientTest {
     @Mock
     private ErrorHandlingClient errorHandlingClient;
     @Mock
-    private Client client;
-    @Mock
-    private WebTarget webTarget;
-    @Mock
     private JsonResponseProcessor jsonResponseProcessor;
-    @Mock
-    private Invocation.Builder builder;
 
     private JsonClient jsonClient;
     private URI testUri = URI.create("/some-uri");
@@ -42,10 +25,6 @@ public class JsonClientTest {
 
     @Before
     public void setup() {
-        when(client.target(any(String.class))).thenReturn(webTarget);
-        when(client.target(any(URI.class))).thenReturn(webTarget);
-        when(webTarget.request(any(MediaType.class))).thenReturn(builder);
-        when(builder.accept(any(MediaType.class))).thenReturn(builder);
         jsonClient = new JsonClient(errorHandlingClient, jsonResponseProcessor);
     }
 

--- a/security-utils/build.gradle
+++ b/security-utils/build.gradle
@@ -1,13 +1,11 @@
 dependencies {
     testCompile 'junit:junit:4.12',
             'org.assertj:assertj-core:1.7.1',
-            'org.mockito:mockito-core:1.10.17'
+            'org.mockito:mockito-core:2.7.6'
 
     compile 'javax.inject:javax.inject:1',
             'com.google.guava:guava:19.0',
-            'io.dropwizard:dropwizard-jackson:1.0.9',
-            'com.fasterxml.jackson.core:jackson-annotations:2.5.1',
-            'com.fasterxml.jackson.core:jackson-databind:2.5.1',
+            'io.dropwizard:dropwizard-jackson:1.1.4',
             'javax.validation:validation-api:1.1.0.Final',
             'commons-codec:commons-codec:1.6',
             'org.slf4j:slf4j-api:1.7.10'

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/DeserializablePublicKeyConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/DeserializablePublicKeyConfiguration.java
@@ -1,13 +1,9 @@
 package uk.gov.ida.common.shared.configuration;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dropwizard.jackson.Discoverable;
 
 import java.security.PublicKey;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
-
-@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type", defaultImpl = PublicKeyFileConfiguration.class)
 public interface DeserializablePublicKeyConfiguration extends Discoverable {
     PublicKey getPublicKey();
 

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfiguration.java
@@ -10,7 +10,6 @@ import javax.validation.constraints.Size;
 import java.security.PublicKey;
 
 @JsonDeserialize(using=EncodedCertificateDeserializer.class)
-@JsonTypeName("base64")
 public class EncodedCertificateConfiguration implements DeserializablePublicKeyConfiguration {
     private PublicKey publicKey;
     private String cert;

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfiguration.java
@@ -11,7 +11,6 @@ import java.security.PrivateKey;
 
 @SuppressWarnings("unused")
 @JsonDeserialize(using=EncodedPrivateKeyDeserializer.class)
-@JsonTypeName("base64")
 public class EncodedPrivateKeyConfiguration implements PrivateKeyConfiguration {
 
     public EncodedPrivateKeyConfiguration(PrivateKey privateKey, String key) {

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyConfiguration.java
@@ -1,13 +1,8 @@
 package uk.gov.ida.common.shared.configuration;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dropwizard.jackson.Discoverable;
-
 import java.security.PrivateKey;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
-
-@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type", defaultImpl = PrivateKeyFileConfiguration.class)
 public interface PrivateKeyConfiguration extends Discoverable {
     PrivateKey getPrivateKey();
 }

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfiguration.java
@@ -10,7 +10,6 @@ import javax.validation.constraints.Size;
 import java.security.PublicKey;
 
 @JsonDeserialize(using=PublicKeyDeserializer.class)
-@JsonTypeName("file")
 public class PublicKeyFileConfiguration implements DeserializablePublicKeyConfiguration {
     private PublicKey publicKey;
     private String cert;

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfigurationTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfigurationTest.java
@@ -25,7 +25,7 @@ public class EncodedCertificateConfigurationTest {
         String path = Resources.getResource("public_key.crt").getFile();
         byte[] cert = Files.readAllBytes(new File(path).toPath());
         String encodedCert = Base64.getEncoder().encodeToString(cert);
-        String jsonConfig = "{\"type\": \"base64\", \"cert\": \"" + encodedCert + "\", \"name\": \"someId\"}";
+        String jsonConfig = "{\"cert\": \"" + encodedCert + "\", \"name\": \"someId\"}";
         EncodedCertificateConfiguration config = objectMapper.readValue(jsonConfig, EncodedCertificateConfiguration.class);
 
         assertThat(config.getPublicKey().getAlgorithm()).isEqualTo("RSA");
@@ -38,20 +38,20 @@ public class EncodedCertificateConfigurationTest {
         String path = Resources.getResource("private_key.pk8").getFile();
         byte[] key = Files.readAllBytes(new File(path).toPath());
         String encodedKey = Base64.getEncoder().encodeToString(key);
-        objectMapper.readValue("{\"type\": \"base64\", \"cert\": \"" + encodedKey + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
+        objectMapper.readValue("{\"cert\": \"" + encodedKey + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
     }
 
     @Test
     public void should_ThrowExceptionWhenStringIsNotBase64Encoded() throws Exception {
         thrown.expect(IllegalArgumentException.class);
 
-        objectMapper.readValue("{\"type\": \"base64\", \"cert\": \"" + "FOOBARBAZ" + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
+        objectMapper.readValue("{\"cert\": \"" + "FOOBARBAZ" + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void should_ThrowExceptionWhenIncorrectKeySpecified() throws Exception {
         String path = getClass().getClassLoader().getResource("empty_file").getPath();
-        String jsonConfig = "{\"type\": \"base64\", \"certFileFoo\": \"" + path + "\", \"name\": \"someId\"}";
+        String jsonConfig = "{\"certFileFoo\": \"" + path + "\", \"name\": \"someId\"}";
         objectMapper.readValue(jsonConfig, EncodedCertificateConfiguration.class);
     }
 }

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfigurationTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfigurationTest.java
@@ -25,7 +25,7 @@ public class EncodedPrivateKeyConfigurationTest {
         String path = Resources.getResource("private_key.pk8").getFile();
         byte[] key = Files.readAllBytes(new File(path).toPath());
         String encodedKey = Base64.getEncoder().encodeToString(key);
-        String jsonConfig = "{\"type\": \"base64\", \"key\": \"" + encodedKey + "\"}";
+        String jsonConfig = "{\"key\": \"" + encodedKey + "\"}";
         EncodedPrivateKeyConfiguration configuration = objectMapper.readValue(jsonConfig, EncodedPrivateKeyConfiguration.class);
         assertThat(configuration.getPrivateKey().getAlgorithm()).isEqualTo("RSA");
     }
@@ -36,11 +36,11 @@ public class EncodedPrivateKeyConfigurationTest {
         thrown.expectCause(any(InvalidKeySpecException.class));
 
         String key = "";
-        objectMapper.readValue("{\"type\": \"base64\", \"key\": \"" + key + "\"}", EncodedPrivateKeyConfiguration.class);
+        objectMapper.readValue("{\"key\": \"" + key + "\"}", EncodedPrivateKeyConfiguration.class);
     }
 
     @Test(expected = EncodedPrivateKeyDeserializer.PrivateKeyNotSpecifiedException.class)
     public void should_throwAnExceptionWhenIncorrectFieldSpecified() throws Exception {
-        objectMapper.readValue("{\"type\": \"base64\", \"privateKeyFoo\": \"" + "foobar" + "\"}", EncodedPrivateKeyConfiguration.class);
+        objectMapper.readValue("{\"privateKeyFoo\": \"" + "foobar" + "\"}", EncodedPrivateKeyConfiguration.class);
     }
 }

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/security/CryptoHelperTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/security/CryptoHelperTest.java
@@ -2,8 +2,8 @@ package uk.gov.ida.common.shared.security;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
 import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,7 +13,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class CryptoHelperTest {
 
     static final String EXAMPLE_IDP = "http://example.com/idp";


### PR DESCRIPTION
This includes also doing the following:
Delete unused code from tests
Update mockito to 2.7.6 as suggested by dropwizard's release notes
Remove unnecessary json type info, which broke in jackson 2.8.x

Authors: @hugh-emerson, @michaelwalker