### PR TITLE
TT-1211: put json type annotations back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 *.ipr
 *.iws
 out/**
+security-utils/out/
 # Package Files #
 *.log
 apps-home

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/DeserializablePublicKeyConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/DeserializablePublicKeyConfiguration.java
@@ -1,9 +1,11 @@
 package uk.gov.ida.common.shared.configuration;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dropwizard.jackson.Discoverable;
 
 import java.security.PublicKey;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface DeserializablePublicKeyConfiguration extends Discoverable {
     PublicKey getPublicKey();
 

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfiguration.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.Size;
 import java.security.PublicKey;
 
 @JsonDeserialize(using=EncodedCertificateDeserializer.class)
+@JsonTypeName("base64")
 public class EncodedCertificateConfiguration implements DeserializablePublicKeyConfiguration {
     private PublicKey publicKey;
     private String cert;

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfiguration.java
@@ -11,6 +11,7 @@ import java.security.PrivateKey;
 
 @SuppressWarnings("unused")
 @JsonDeserialize(using=EncodedPrivateKeyDeserializer.class)
+@JsonTypeName("base64")
 public class EncodedPrivateKeyConfiguration implements PrivateKeyConfiguration {
 
     public EncodedPrivateKeyConfiguration(PrivateKey privateKey, String key) {

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyConfiguration.java
@@ -1,8 +1,10 @@
 package uk.gov.ida.common.shared.configuration;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dropwizard.jackson.Discoverable;
 import java.security.PrivateKey;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface PrivateKeyConfiguration extends Discoverable {
     PrivateKey getPrivateKey();
 }

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyFileConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyFileConfiguration.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.common.shared.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import javax.validation.Valid;
@@ -10,6 +11,7 @@ import java.security.PrivateKey;
 
 @SuppressWarnings("unused")
 @JsonDeserialize(using=PrivateKeyFileDeserializer.class)
+@JsonTypeName("file")
 public class PrivateKeyFileConfiguration implements PrivateKeyConfiguration {
 
     public PrivateKeyFileConfiguration(PrivateKey privateKey, String keyFile) {

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfiguration.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.Size;
 import java.security.PublicKey;
 
 @JsonDeserialize(using=PublicKeyDeserializer.class)
+@JsonTypeName("file")
 public class PublicKeyFileConfiguration implements DeserializablePublicKeyConfiguration {
     private PublicKey publicKey;
     private String cert;

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfigurationTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfigurationTest.java
@@ -25,7 +25,7 @@ public class EncodedCertificateConfigurationTest {
         String path = Resources.getResource("public_key.crt").getFile();
         byte[] cert = Files.readAllBytes(new File(path).toPath());
         String encodedCert = Base64.getEncoder().encodeToString(cert);
-        String jsonConfig = "{\"cert\": \"" + encodedCert + "\", \"name\": \"someId\"}";
+        String jsonConfig = "{\"type\": \"base64\", \"cert\": \"" + encodedCert + "\", \"name\": \"someId\"}";
         EncodedCertificateConfiguration config = objectMapper.readValue(jsonConfig, EncodedCertificateConfiguration.class);
 
         assertThat(config.getPublicKey().getAlgorithm()).isEqualTo("RSA");
@@ -38,20 +38,20 @@ public class EncodedCertificateConfigurationTest {
         String path = Resources.getResource("private_key.pk8").getFile();
         byte[] key = Files.readAllBytes(new File(path).toPath());
         String encodedKey = Base64.getEncoder().encodeToString(key);
-        objectMapper.readValue("{\"cert\": \"" + encodedKey + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
+        objectMapper.readValue("{\"type\": \"base64\", \"cert\": \"" + encodedKey + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
     }
 
     @Test
     public void should_ThrowExceptionWhenStringIsNotBase64Encoded() throws Exception {
         thrown.expect(IllegalArgumentException.class);
 
-        objectMapper.readValue("{\"cert\": \"" + "FOOBARBAZ" + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
+        objectMapper.readValue("{\"type\": \"base64\", \"cert\": \"" + "FOOBARBAZ" + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void should_ThrowExceptionWhenIncorrectKeySpecified() throws Exception {
         String path = getClass().getClassLoader().getResource("empty_file").getPath();
-        String jsonConfig = "{\"certFileFoo\": \"" + path + "\", \"name\": \"someId\"}";
+        String jsonConfig = "{\"type\": \"base64\", \"certFileFoo\": \"" + path + "\", \"name\": \"someId\"}";
         objectMapper.readValue(jsonConfig, EncodedCertificateConfiguration.class);
     }
 }

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfigurationTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfigurationTest.java
@@ -25,7 +25,7 @@ public class EncodedPrivateKeyConfigurationTest {
         String path = Resources.getResource("private_key.pk8").getFile();
         byte[] key = Files.readAllBytes(new File(path).toPath());
         String encodedKey = Base64.getEncoder().encodeToString(key);
-        String jsonConfig = "{\"key\": \"" + encodedKey + "\"}";
+        String jsonConfig = "{\"type\": \"base64\", \"key\": \"" + encodedKey + "\"}";
         EncodedPrivateKeyConfiguration configuration = objectMapper.readValue(jsonConfig, EncodedPrivateKeyConfiguration.class);
         assertThat(configuration.getPrivateKey().getAlgorithm()).isEqualTo("RSA");
     }
@@ -36,11 +36,11 @@ public class EncodedPrivateKeyConfigurationTest {
         thrown.expectCause(any(InvalidKeySpecException.class));
 
         String key = "";
-        objectMapper.readValue("{\"key\": \"" + key + "\"}", EncodedPrivateKeyConfiguration.class);
+        objectMapper.readValue("{\"type\": \"base64\", \"key\": \"" + key + "\"}", EncodedPrivateKeyConfiguration.class);
     }
 
     @Test(expected = EncodedPrivateKeyDeserializer.PrivateKeyNotSpecifiedException.class)
     public void should_throwAnExceptionWhenIncorrectFieldSpecified() throws Exception {
-        objectMapper.readValue("{\"privateKeyFoo\": \"" + "foobar" + "\"}", EncodedPrivateKeyConfiguration.class);
+        objectMapper.readValue("{\"type\": \"base64\", \"privateKeyFoo\": \"" + "foobar" + "\"}", EncodedPrivateKeyConfiguration.class);
     }
 }

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/PrivateKeyFileConfigurationTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/PrivateKeyFileConfigurationTest.java
@@ -22,14 +22,14 @@ public class PrivateKeyFileConfigurationTest {
     @Test
     public void should_loadPrivateKeyFromJSON() throws Exception {
         String path = getClass().getClassLoader().getResource("private_key.pk8").getPath();
-        PrivateKeyFileConfiguration privateKeyFileConfiguration = objectMapper.readValue("{\"keyFile\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
+        PrivateKeyFileConfiguration privateKeyFileConfiguration = objectMapper.readValue("{\"type\": \"file\", \"keyFile\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
 
         assertThat(privateKeyFileConfiguration.getPrivateKey().getAlgorithm()).isEqualTo("RSA");
     }
 
     @Test(expected = FileNotFoundException.class)
     public void should_ThrowFooExceptionWhenFileDoesNotExist() throws Exception {
-        objectMapper.readValue("{\"keyFile\": \"/foo/bar\"}", PrivateKeyFileConfiguration.class);
+        objectMapper.readValue("{\"type\": \"file\", \"keyFile\": \"/foo/bar\"}", PrivateKeyFileConfiguration.class);
     }
 
     @Test
@@ -38,12 +38,12 @@ public class PrivateKeyFileConfigurationTest {
         thrown.expectCause(any(InvalidKeySpecException.class));
 
         String path = getClass().getClassLoader().getResource("empty_file").getPath();
-        objectMapper.readValue("{\"keyFile\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
+        objectMapper.readValue("{\"type\": \"file\", \"keyFile\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
     }
 
     @Test(expected = PrivateKeyFileDeserializer.PrivateKeyPathNotSpecifiedException.class)
     public void should_throwAnExceptionWhenIncorrectKeySpecified() throws Exception {
         String path = getClass().getClassLoader().getResource("empty_file").getPath();
-        objectMapper.readValue("{\"privateKeyFoo\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
+        objectMapper.readValue("{\"type\": \"file\", \"privateKeyFoo\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
     }
 }

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfigurationTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfigurationTest.java
@@ -21,14 +21,14 @@ public class PublicKeyFileConfigurationTest {
     @Test
     public void should_loadPublicKeyFromJSON() throws Exception {
         String path = getClass().getClassLoader().getResource("public_key.crt").getPath();
-        PublicKeyFileConfiguration publicKeyConfiguration = objectMapper.readValue("{\"certFile\": \"" + path + "\", \"name\": \"someId\"}", PublicKeyFileConfiguration.class);
+        PublicKeyFileConfiguration publicKeyConfiguration = objectMapper.readValue("{\"type\": \"file\", \"certFile\": \"" + path + "\", \"name\": \"someId\"}", PublicKeyFileConfiguration.class);
 
         assertThat(publicKeyConfiguration.getPublicKey().getAlgorithm()).isEqualTo("RSA");
     }
 
     @Test(expected = NoSuchFileException.class)
     public void should_ThrowExceptionWhenFileDoesNotExist() throws Exception {
-        objectMapper.readValue("{\"certFile\": \"/foo/bar\", \"name\": \"someId\"}", PublicKeyFileConfiguration.class);
+        objectMapper.readValue("{\"type\": \"file\", \"certFile\": \"/foo/bar\", \"name\": \"someId\"}", PublicKeyFileConfiguration.class);
     }
 
     @Test
@@ -37,12 +37,12 @@ public class PublicKeyFileConfigurationTest {
         thrown.expectCause(any(CertificateException.class));
 
         String path = getClass().getClassLoader().getResource("empty_file").getPath();
-        objectMapper.readValue("{\"certFile\": \"" + path + "\", \"name\": \"someId\"}", PublicKeyFileConfiguration.class);
+        objectMapper.readValue("{\"type\": \"file\", \"certFile\": \"" + path + "\", \"name\": \"someId\"}", PublicKeyFileConfiguration.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void should_ThrowExceptionWhenIncorrectKeySpecified() throws Exception {
         String path = getClass().getClassLoader().getResource("empty_file").getPath();
-        objectMapper.readValue("{\"certFileFoo\": \"" + path + "\", \"name\": \"someId\"}", PublicKeyFileConfiguration.class);
+        objectMapper.readValue("{\"type\": \"file\", \"certFileFoo\": \"" + path + "\", \"name\": \"someId\"}", PublicKeyFileConfiguration.class);
     }
 }


### PR DESCRIPTION
Earlier commit removed JsonTypeInfo annotations but they are actually required
Still don't add the defaultImpl because then there are errors in the latest version of jackson.

Authors: @hugh-emerson, @michaelWalker