### PR TITLE
TT-1211: upgrading dropwizard

### DIFF
--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/DeserializablePublicKeyConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/DeserializablePublicKeyConfiguration.java
@@ -1,11 +1,11 @@
 package uk.gov.ida.common.shared.configuration;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.dropwizard.jackson.Discoverable;
 
 import java.security.PublicKey;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonDeserialize(using=DeserializablePublicKeyConfigurationDeserializer.class)
 public interface DeserializablePublicKeyConfiguration extends Discoverable {
     PublicKey getPublicKey();
 

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/DeserializablePublicKeyConfigurationDeserializer.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/DeserializablePublicKeyConfigurationDeserializer.java
@@ -1,0 +1,27 @@
+package uk.gov.ida.common.shared.configuration;
+
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class DeserializablePublicKeyConfigurationDeserializer extends JsonDeserializer<DeserializablePublicKeyConfiguration> {
+    @Override
+    public DeserializablePublicKeyConfiguration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        // Setting the Codec explicitly is needed when this executes with the YAMLParser
+        // for example, when our Dropwizard apps start. The codec doesn't need to be set
+        // when the JsonParser implementation is used.
+        p.setCodec(new ObjectMapper());
+        JsonNode node = p.getCodec().readTree(p);
+
+        JsonNode certFileNode = node.get("certFile");
+        if(certFileNode != null) {
+            return p.getCodec().treeToValue(node, PublicKeyFileConfiguration.class);
+        }
+        return p.getCodec().treeToValue(node, EncodedCertificateConfiguration.class);
+    }
+}

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfiguration.java
@@ -10,7 +10,6 @@ import javax.validation.constraints.Size;
 import java.security.PublicKey;
 
 @JsonDeserialize(using=EncodedCertificateDeserializer.class)
-@JsonTypeName("base64")
 public class EncodedCertificateConfiguration implements DeserializablePublicKeyConfiguration {
     private PublicKey publicKey;
     private String cert;

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfiguration.java
@@ -11,7 +11,6 @@ import java.security.PrivateKey;
 
 @SuppressWarnings("unused")
 @JsonDeserialize(using=EncodedPrivateKeyDeserializer.class)
-@JsonTypeName("base64")
 public class EncodedPrivateKeyConfiguration implements PrivateKeyConfiguration {
 
     public EncodedPrivateKeyConfiguration(PrivateKey privateKey, String key) {

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyConfiguration.java
@@ -1,10 +1,10 @@
 package uk.gov.ida.common.shared.configuration;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.dropwizard.jackson.Discoverable;
 import java.security.PrivateKey;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonDeserialize(using=PrivateKeyConfigurationDeserializer.class)
 public interface PrivateKeyConfiguration extends Discoverable {
     PrivateKey getPrivateKey();
 }

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyConfigurationDeserializer.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyConfigurationDeserializer.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.common.shared.configuration;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class PrivateKeyConfigurationDeserializer extends JsonDeserializer<PrivateKeyConfiguration> {
+    @Override
+    public PrivateKeyConfiguration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        // Setting the Codec explicitly is needed when this executes with the YAMLParser
+        // for example, when our Dropwizard apps start. The codec doesn't need to be set
+        // when the JsonParser implementation is used.
+        p.setCodec(new ObjectMapper());
+        JsonNode node = p.getCodec().readTree(p);
+
+        JsonNode certFileNode = node.get("keyFile");
+        if(certFileNode != null) {
+            return p.getCodec().treeToValue(node, PrivateKeyFileConfiguration.class);
+        }
+        return p.getCodec().treeToValue(node, EncodedPrivateKeyConfiguration.class);
+    }
+}

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyFileConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PrivateKeyFileConfiguration.java
@@ -11,7 +11,6 @@ import java.security.PrivateKey;
 
 @SuppressWarnings("unused")
 @JsonDeserialize(using=PrivateKeyFileDeserializer.class)
-@JsonTypeName("file")
 public class PrivateKeyFileConfiguration implements PrivateKeyConfiguration {
 
     public PrivateKeyFileConfiguration(PrivateKey privateKey, String keyFile) {

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfiguration.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfiguration.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.common.shared.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import javax.validation.Valid;
@@ -9,8 +8,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.security.PublicKey;
 
-@JsonDeserialize(using=PublicKeyDeserializer.class)
-@JsonTypeName("file")
+@JsonDeserialize(using=PublicKeyFileConfigurationDeserializer.class)
 public class PublicKeyFileConfiguration implements DeserializablePublicKeyConfiguration {
     private PublicKey publicKey;
     private String cert;

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfigurationDeserializer.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/configuration/PublicKeyFileConfigurationDeserializer.java
@@ -14,7 +14,7 @@ import java.nio.file.Paths;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 
-public class PublicKeyDeserializer extends JsonDeserializer<PublicKeyFileConfiguration> {
+public class PublicKeyFileConfigurationDeserializer extends JsonDeserializer<PublicKeyFileConfiguration> {
     @Override
     public PublicKeyFileConfiguration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         // Setting the Codec explicitly is needed when this executes with the YAMLParser

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfigurationTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedCertificateConfigurationTest.java
@@ -25,7 +25,7 @@ public class EncodedCertificateConfigurationTest {
         String path = Resources.getResource("public_key.crt").getFile();
         byte[] cert = Files.readAllBytes(new File(path).toPath());
         String encodedCert = Base64.getEncoder().encodeToString(cert);
-        String jsonConfig = "{\"type\": \"base64\", \"cert\": \"" + encodedCert + "\", \"name\": \"someId\"}";
+        String jsonConfig = "{\"cert\": \"" + encodedCert + "\", \"name\": \"someId\"}";
         EncodedCertificateConfiguration config = objectMapper.readValue(jsonConfig, EncodedCertificateConfiguration.class);
 
         assertThat(config.getPublicKey().getAlgorithm()).isEqualTo("RSA");
@@ -38,20 +38,20 @@ public class EncodedCertificateConfigurationTest {
         String path = Resources.getResource("private_key.pk8").getFile();
         byte[] key = Files.readAllBytes(new File(path).toPath());
         String encodedKey = Base64.getEncoder().encodeToString(key);
-        objectMapper.readValue("{\"type\": \"base64\", \"cert\": \"" + encodedKey + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
+        objectMapper.readValue("{\"cert\": \"" + encodedKey + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
     }
 
     @Test
     public void should_ThrowExceptionWhenStringIsNotBase64Encoded() throws Exception {
         thrown.expect(IllegalArgumentException.class);
 
-        objectMapper.readValue("{\"type\": \"base64\", \"cert\": \"" + "FOOBARBAZ" + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
+        objectMapper.readValue("{\"cert\": \"" + "FOOBARBAZ" + "\", \"name\": \"someId\"}", EncodedCertificateConfiguration.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void should_ThrowExceptionWhenIncorrectKeySpecified() throws Exception {
         String path = getClass().getClassLoader().getResource("empty_file").getPath();
-        String jsonConfig = "{\"type\": \"base64\", \"certFileFoo\": \"" + path + "\", \"name\": \"someId\"}";
+        String jsonConfig = "{\"certFileFoo\": \"" + path + "\", \"name\": \"someId\"}";
         objectMapper.readValue(jsonConfig, EncodedCertificateConfiguration.class);
     }
 }

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfigurationTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/EncodedPrivateKeyConfigurationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.common.shared.configuration;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import org.junit.Rule;
@@ -25,7 +26,7 @@ public class EncodedPrivateKeyConfigurationTest {
         String path = Resources.getResource("private_key.pk8").getFile();
         byte[] key = Files.readAllBytes(new File(path).toPath());
         String encodedKey = Base64.getEncoder().encodeToString(key);
-        String jsonConfig = "{\"type\": \"base64\", \"key\": \"" + encodedKey + "\"}";
+        String jsonConfig = "{\"key\": \"" + encodedKey + "\"}";
         EncodedPrivateKeyConfiguration configuration = objectMapper.readValue(jsonConfig, EncodedPrivateKeyConfiguration.class);
         assertThat(configuration.getPrivateKey().getAlgorithm()).isEqualTo("RSA");
     }
@@ -36,11 +37,11 @@ public class EncodedPrivateKeyConfigurationTest {
         thrown.expectCause(any(InvalidKeySpecException.class));
 
         String key = "";
-        objectMapper.readValue("{\"type\": \"base64\", \"key\": \"" + key + "\"}", EncodedPrivateKeyConfiguration.class);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false).readValue("{\"key\": \"" + key + "\"}", EncodedPrivateKeyConfiguration.class);
     }
 
     @Test(expected = EncodedPrivateKeyDeserializer.PrivateKeyNotSpecifiedException.class)
     public void should_throwAnExceptionWhenIncorrectFieldSpecified() throws Exception {
-        objectMapper.readValue("{\"type\": \"base64\", \"privateKeyFoo\": \"" + "foobar" + "\"}", EncodedPrivateKeyConfiguration.class);
+        objectMapper.readValue("{\"privateKeyFoo\": \"" + "foobar" + "\"}", EncodedPrivateKeyConfiguration.class);
     }
 }

--- a/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/PrivateKeyFileConfigurationTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/configuration/PrivateKeyFileConfigurationTest.java
@@ -22,14 +22,14 @@ public class PrivateKeyFileConfigurationTest {
     @Test
     public void should_loadPrivateKeyFromJSON() throws Exception {
         String path = getClass().getClassLoader().getResource("private_key.pk8").getPath();
-        PrivateKeyFileConfiguration privateKeyFileConfiguration = objectMapper.readValue("{\"type\": \"file\", \"keyFile\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
+        PrivateKeyFileConfiguration privateKeyFileConfiguration = objectMapper.readValue("{\"keyFile\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
 
         assertThat(privateKeyFileConfiguration.getPrivateKey().getAlgorithm()).isEqualTo("RSA");
     }
 
     @Test(expected = FileNotFoundException.class)
     public void should_ThrowFooExceptionWhenFileDoesNotExist() throws Exception {
-        objectMapper.readValue("{\"type\": \"file\", \"keyFile\": \"/foo/bar\"}", PrivateKeyFileConfiguration.class);
+        objectMapper.readValue("{\"keyFile\": \"/foo/bar\"}", PrivateKeyFileConfiguration.class);
     }
 
     @Test
@@ -38,12 +38,12 @@ public class PrivateKeyFileConfigurationTest {
         thrown.expectCause(any(InvalidKeySpecException.class));
 
         String path = getClass().getClassLoader().getResource("empty_file").getPath();
-        objectMapper.readValue("{\"type\": \"file\", \"keyFile\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
+        objectMapper.readValue("{\"keyFile\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
     }
 
     @Test(expected = PrivateKeyFileDeserializer.PrivateKeyPathNotSpecifiedException.class)
     public void should_throwAnExceptionWhenIncorrectKeySpecified() throws Exception {
         String path = getClass().getClassLoader().getResource("empty_file").getPath();
-        objectMapper.readValue("{\"type\": \"file\", \"privateKeyFoo\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
+        objectMapper.readValue("{\"privateKeyFoo\": \"" + path + "\"}", PrivateKeyFileConfiguration.class);
     }
 }


### PR DESCRIPTION
As part of the upgrade, jackson has upgraded to 2.8.
They over-eagerly prevent our polymorphism (https://github.com/FasterXML/jackson-databind/issues/1358)
I removed the defaultImpl in the last commit but actually that would cause a lot of extra work.
I believe the best solution for now is to use custom deserialisers for the interfaces.
Tested by running msa and stubs with this change locally.

Solo: hugh-emerson