### PR TITLE
BAU: Fix failing expired cert validation test.

### DIFF
--- a/security-utils/src/test/java/uk/gov/ida/common/shared/security/verification/CertificateChainValidatorTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/security/verification/CertificateChainValidatorTest.java
@@ -78,7 +78,7 @@ public class CertificateChainValidatorTest {
         assertThat(certificateValidity.isValid()).isEqualTo(false);
         CertPathValidatorException exception = certificateValidity.getException().get();
         assertThat(exception.getReason()).isEqualTo(BasicReason.EXPIRED);
-        assertThat(exception.getMessage()).isEqualTo("timestamp check failed");
+        assertThat(exception.getMessage()).isEqualTo("validity check failed");
     }
 
     @Test


### PR DESCRIPTION
The recent Java security update slightly changed the way in which cert
validation errors are reported.
We have now updated the test to reflect this.
The error message is now more generic, but the 'reason' still specifies
that the failure is due to an expired cert.

Authors: @michaelwalker, @mahmudh