### PR TITLE
bau: Loosen test that was failing on some machines but not Jenkins

### DIFF
--- a/security-utils/src/test/java/uk/gov/ida/common/shared/security/verification/CertificateChainValidatorTest.java
+++ b/security-utils/src/test/java/uk/gov/ida/common/shared/security/verification/CertificateChainValidatorTest.java
@@ -78,7 +78,6 @@ public class CertificateChainValidatorTest {
         assertThat(certificateValidity.isValid()).isEqualTo(false);
         CertPathValidatorException exception = certificateValidity.getException().get();
         assertThat(exception.getReason()).isEqualTo(BasicReason.EXPIRED);
-        assertThat(exception.getMessage()).isEqualTo("validity check failed");
     }
 
     @Test


### PR DESCRIPTION
There seems to be some difference in the exception messages thrown by
the certificate timestamp checker depending on the system. It's probably
to do with the version of java. The test is probably too strict (do we
actually care about the exact exception message thrown?), but this at
least means the test will pass consistently so nobody else will have to
waste time tracking down the failure.

Authors: @richardtowers