### PR TITLE
ABD-35: Update to use latest version of event emitter lib

### DIFF
--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -14,5 +14,5 @@ dependencies {
             "javax.ws.rs:javax.ws.rs-api:2.0.1",
             "uk.gov.ida:dropwizard-logstash:1.1.4-49",
             "org.apache.commons:commons-lang3:3.3.2",
-            "uk.gov.ida:verify-event-emitter:0.0.1-9"
+            "uk.gov.ida:verify-event-emitter:0.0.1-30"
 }


### PR DESCRIPTION
Latest version of event emitter library enables clients to send encrypted events to stub SQS or real SQS.

Authors: @adityapahuja