### PR TITLE
bau: Build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+env:
+  - VERIFY_USE_PUBLIC_BINARIES=true
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - openjdk8
+matrix:
+  allow_failures:
+  - jdk: oraclejdk9
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-
 # Verify Utils Libraries
+
+[![Build Status](https://travis-ci.org/alphagov/verify-utils-libs.svg?branch=master)](https://travis-ci.org/alphagov/verify-utils-libs)
 
 Libraries for performing various utility operations within Verify. These include:
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,17 @@ subprojects {
 
 
     repositories {
-        maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+            logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+
+            maven { url  "https://dl.bintray.com/alphagov/maven"      } // For dropwizard-logstash
+            maven { url  "https://dl.bintray.com/alphagov/maven-test" } // For other public verify binaries
+
+            jcenter()
+        }
+        else {
+            maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        }
     }
 
 

--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -14,9 +14,9 @@ dependencies {
             "io.dropwizard:dropwizard-core:$dependencyVersions.dropwizardVersion",
             "io.dropwizard:dropwizard-client:$dependencyVersions.dropwizardVersion",
             "javax.ws.rs:javax.ws.rs-api:2.0.1",
-            "uk.gov.ida:dropwizard-logstash:1.1.4-49",
+            "uk.gov.ida:dropwizard-logstash:1.2.2-67",
             "org.apache.commons:commons-lang3:3.3.2",
-            "uk.gov.ida:verify-event-emitter:0.0.1-30"
+            "uk.gov.ida:verify-event-emitter:0.0.1-38"
 }
 
 bintray {


### PR DESCRIPTION
I've had to upgrade dropwizard-logstash quite a long way here (1.1.4-49 to 1.2.2-67) because it wasn't being published to bintray properly.

Otherwise just doing the same environment variable feature flag to use the public binaries instead of the ones on artifactory, and setting up travis.