### PR TITLE
49: Upgrade Dropwizard to 1.3.5

### DIFF
--- a/common-utils/build.gradle
+++ b/common-utils/build.gradle
@@ -12,7 +12,7 @@ dependencies {
             'joda-time:joda-time:2.7',
             'org.yaml:snakeyaml:1.12',
             'javax.validation:validation-api:1.1.0.Final',
-            'io.dropwizard:dropwizard-logging:1.1.4'
+            'io.dropwizard:dropwizard-logging:1.3.5'
 }
 
 bintray {

--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -6,7 +6,7 @@ dependencies {
             "org.mockito:mockito-core:2.7.6"
 
     def dependencyVersions = [
-            dropwizardVersion:"1.1.4"
+            dropwizardVersion:"1.3.5"
     ]
 
     compile "javax.inject:javax.inject:1",
@@ -14,7 +14,7 @@ dependencies {
             "io.dropwizard:dropwizard-core:$dependencyVersions.dropwizardVersion",
             "io.dropwizard:dropwizard-client:$dependencyVersions.dropwizardVersion",
             "javax.ws.rs:javax.ws.rs-api:2.0.1",
-            "uk.gov.ida:dropwizard-logstash:1.2.2-67",
+            "uk.gov.ida:dropwizard-logstash:1.3.5-68",
             "org.apache.commons:commons-lang3:3.3.2",
             "uk.gov.ida:verify-event-emitter:0.0.1-38"
 }

--- a/security-utils/build.gradle
+++ b/security-utils/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     compile 'javax.inject:javax.inject:1',
             'com.google.guava:guava:19.0',
-            'io.dropwizard:dropwizard-jackson:1.2.2',
+            'io.dropwizard:dropwizard-jackson:1.3.5',
             'javax.validation:validation-api:1.1.0.Final',
             'commons-codec:commons-codec:1.6',
             'org.slf4j:slf4j-api:1.7.10'


### PR DESCRIPTION
Upgrade Dropwizard to 1.3.5 to fix various security issues.

Authors: @adityapahuja