### PR TITLE
BAU: Add unknown property object mapper helper

### DIFF
--- a/common-utils/build.gradle
+++ b/common-utils/build.gradle
@@ -12,7 +12,8 @@ dependencies {
             'joda-time:joda-time:2.7',
             'org.yaml:snakeyaml:1.12',
             'javax.validation:validation-api:1.1.0.Final',
-            'io.dropwizard:dropwizard-logging:1.3.5'
+            'io.dropwizard:dropwizard-logging:1.3.5',
+            'io.dropwizard:dropwizard-configuration:1.3.5'
 }
 
 bintray {

--- a/common-utils/src/main/java/uk/gov/ida/shared/utils/AllowUnknownPropertiesConfigurationFactoryFactory.java
+++ b/common-utils/src/main/java/uk/gov/ida/shared/utils/AllowUnknownPropertiesConfigurationFactoryFactory.java
@@ -1,0 +1,12 @@
+package uk.gov.ida.shared.utils;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
+
+public class AllowUnknownPropertiesConfigurationFactoryFactory<T> extends DefaultConfigurationFactoryFactory<T> {
+    @Override
+    protected ObjectMapper configureObjectMapper(ObjectMapper objectMapper) {
+        return objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+}


### PR DESCRIPTION
- Dropwizard-guicier version >1.0 contain a class
that stops Dropwizard's attempts to disabled the
AllowUnknownProperties behavious on the global ObjectMapper
(at least during configuration file deserialization)
- As we move away from Guice, it would be nice to be able to
implement this behaviour
- By adding this factory in the Dropwizard bootstrap we will
be able to explicitly allow this behaviour instead of relying
on dropwizard-guicier doing it magically