### PR TITLE
HUB-142: Add MSA Retries with Back-off

### DIFF
--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -1,13 +1,15 @@
 plugins { id "com.jfrog.bintray" version "1.8.0" }
 
 dependencies {
-    testCompile "junit:junit:4.12",
-            "org.assertj:assertj-core:1.7.1",
-            "org.mockito:mockito-core:2.7.6"
-
     def dependencyVersions = [
             dropwizardVersion:"1.3.5"
     ]
+
+    testCompile "junit:junit:4.12",
+            "org.assertj:assertj-core:1.7.1",
+            "org.mockito:mockito-core:2.7.6",
+            "com.github.tomakehurst:wiremock:2.16.0",
+            "io.dropwizard:dropwizard-testing:$dependencyVersions.dropwizardVersion"
 
     compile "javax.inject:javax.inject:1",
             "javax.servlet:javax.servlet-api:3.1.0",

--- a/rest-utils/src/main/java/uk/gov/ida/configuration/JerseyClientWithRetryBackoffConfiguration.java
+++ b/rest-utils/src/main/java/uk/gov/ida/configuration/JerseyClientWithRetryBackoffConfiguration.java
@@ -1,0 +1,32 @@
+package uk.gov.ida.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.util.Duration;
+
+import java.util.List;
+
+public class JerseyClientWithRetryBackoffConfiguration extends JerseyClientConfiguration{
+
+    @JsonProperty
+    private Duration retryBackoffPeriod = Duration.seconds(0);
+
+    @JsonProperty
+    private List<String> retryExceptionNames = null;
+
+    public Duration getRetryBackoffPeriod() {
+        return retryBackoffPeriod;
+    }
+
+    public List<String> getRetryExceptionNames() {
+        return retryExceptionNames;
+    }
+
+    public void setRetryBackoffPeriod(Duration retryBackoffPeriod) {
+        this.retryBackoffPeriod = retryBackoffPeriod;
+    }
+
+    public void setRetryExceptionNames(List<String> retryExceptionNames){
+        this.retryExceptionNames = retryExceptionNames;
+    }
+}

--- a/rest-utils/src/main/java/uk/gov/ida/restclient/TimeoutRequestRetryWithBackoffHandler.java
+++ b/rest-utils/src/main/java/uk/gov/ida/restclient/TimeoutRequestRetryWithBackoffHandler.java
@@ -1,0 +1,71 @@
+package uk.gov.ida.restclient;
+
+import io.dropwizard.util.Duration;
+import org.apache.http.HttpRequest;
+import org.apache.http.RequestLine;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.text.MessageFormat.format;
+
+public class TimeoutRequestRetryWithBackoffHandler implements HttpRequestRetryHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(TimeoutRequestRetryHandler.class);
+    private final int numRetries;
+    private final Duration retryBackoffPeriod;
+    private final List<Class> defaultRetryExceptions = Arrays.asList(new Class[]{ ConnectTimeoutException.class, SocketTimeoutException.class}) ;
+    private List<Class> retryExceptions;
+
+    public TimeoutRequestRetryWithBackoffHandler(int numRetries, Duration retryBackoffPeriod) {
+        this.numRetries = numRetries;
+        this.retryBackoffPeriod = retryBackoffPeriod;
+        this.retryExceptions = defaultRetryExceptions;
+    }
+
+    public TimeoutRequestRetryWithBackoffHandler(int numRetries, Duration retryBackoffPeriod,List<String> retryExceptionNames) {
+        this(numRetries, retryBackoffPeriod);
+        if (retryExceptions != null) {
+            this.retryExceptions = new ArrayList<>();
+            for(String className : retryExceptionNames) {
+                try {
+                    this.retryExceptions.add(Class.forName(className));
+                } catch(ClassNotFoundException e) {
+                    LOG.error(format("Class {0} specified in exception class name list does not exist", className));
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean retryRequest(IOException e, int executionCount, HttpContext httpContext) {
+        LOG.info("Retry request made.", e);
+        if (retryExceptions.contains(e.getClass()) && executionCount <= numRetries) {
+            String uri = null;
+            String httpMethod = null;
+            try {
+                final HttpCoreContext coreContext = HttpCoreContext.adapt(httpContext);
+                final HttpRequest request = coreContext.getRequest();
+                final RequestLine requestLine = request.getRequestLine();
+                uri = requestLine.getUri();
+                httpMethod = requestLine.getMethod();
+                LOG.info(format("Backing off for {0} milliseconds before retry", this.retryBackoffPeriod));
+                Thread.sleep(executionCount * this.retryBackoffPeriod.toMilliseconds());
+            } catch(InterruptedException ex) {
+                LOG.error("Thread interrupted during backoff period");
+            } finally {
+                LOG.info(format("Retrying {0} of {1}, to {2} / {3}", executionCount, numRetries, httpMethod, uri));
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/rest-utils/src/test/java/uk/gov/ida/restclient/RestClientTimeoutTest.java
+++ b/rest-utils/src/test/java/uk/gov/ida/restclient/RestClientTimeoutTest.java
@@ -1,0 +1,267 @@
+package uk.gov.ida.restclient;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import io.dropwizard.util.Duration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.apache.http.NoHttpResponseException;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.ida.configuration.JerseyClientWithRetryBackoffConfiguration;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.Arrays;
+
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RestClientTimeoutTest {
+
+    @ClassRule
+    public static final DropwizardAppRule testAppRule = new DropwizardAppRule(TestApplication.class);
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    @Test
+    public void socketTimeoutRetryWithBackoffTests_thirdCallSucceeds() {
+        final String firstCallState = "Call 1 Complete";
+        final String secondCallState = "Call 2 Complete";
+        final String thirdCallState = "Call 3 Complete";
+        final String scenarioName = "socket timeout scenario scenario";
+        final String resourcePath = "/delayed-resource";
+
+
+        stubFor(get(urlEqualTo(resourcePath)).inScenario(scenarioName)
+            .withHeader("Accept", equalTo("application/json"))
+            .whenScenarioStateIs(STARTED)
+            .willReturn(aResponse()
+                .withFixedDelay(2000)
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(format("{ \"message\": \"%s\" }", firstCallState)))
+            .willSetStateTo(firstCallState)
+        );
+
+        stubFor(get(urlEqualTo(resourcePath)).inScenario(scenarioName)
+            .withHeader("Accept", equalTo("application/json"))
+            .whenScenarioStateIs(firstCallState)
+            .willReturn(aResponse()
+                .withFixedDelay(2000)
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(format("{ \"message\": \"%s\" }", secondCallState)))
+            .willSetStateTo(secondCallState)
+        );
+
+        stubFor(get(urlEqualTo(resourcePath)).inScenario(scenarioName)
+            .withHeader("Accept", equalTo("application/json"))
+            .whenScenarioStateIs(secondCallState)
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(format("{ \"message\": \"%s\" }", thirdCallState)))
+            .willSetStateTo(thirdCallState)
+        );
+
+        JerseyClientWithRetryBackoffConfiguration clientConfig = new JerseyClientWithRetryBackoffConfiguration();
+        clientConfig.setRetries(3);
+        clientConfig.setRetryBackoffPeriod(Duration.milliseconds(1000));
+        clientConfig.setTimeout(Duration.milliseconds(1000));
+        clientConfig.setConnectionTimeout(Duration.milliseconds(1000));
+
+        ClientProvider provider = new ClientProvider(
+            testAppRule.getEnvironment(),
+            clientConfig,
+            true,
+            "socketTimeoutRetryWithBackoffTests_thirdCallSucceedsClient"
+        );
+        Client client = provider.get();
+
+        WebTarget target = client.target(format("http://localhost:%d%s", wireMockRule.port(), resourcePath));
+        final Invocation.Builder request = target.request();
+        long start = System.currentTimeMillis();
+
+        final Response response = request.accept(MediaType.APPLICATION_JSON).get();
+
+        int status = response.getStatus();
+        long end = System.currentTimeMillis();
+
+        assertEquals(200, status);
+        Scenario scenario = this.getScenario(scenarioName);
+
+        assertEquals(thirdCallState, scenario.getState());
+
+        assertTrue((end - start) >= getTotalBackoffPeriod(2, clientConfig.getRetryBackoffPeriod()));
+    }
+
+    @Test
+    public void multipleErrorRetryWithBackoffTests_forthCallSucceeds() {
+        final String firstCallState = "Call 1 Complete";
+        final String secondCallState = "Call 2 Complete";
+        final String thirdCallState = "Call 3 Complete";
+        final String forthCallState = "Call 4 Complete";
+        final String scenarioName = "multiple error scenario";
+        final String resourcePath = "/multiple-error-resource";
+
+
+        stubFor(get(urlEqualTo(resourcePath)).inScenario(scenarioName)
+            .withHeader("Accept", equalTo("application/json"))
+            .whenScenarioStateIs(STARTED)
+            .willReturn(aResponse()
+                .withFixedDelay(2000)
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(format("{ \"message\": \"%s\" }", firstCallState)))
+            .willSetStateTo(firstCallState)
+        );
+
+        stubFor(get(urlEqualTo(resourcePath)).inScenario(scenarioName)
+            .withHeader("Accept", equalTo("application/json"))
+            .whenScenarioStateIs(firstCallState)
+            .willReturn(aResponse()
+                .withFault(Fault.CONNECTION_RESET_BY_PEER))
+            .willSetStateTo(secondCallState)
+        );
+
+        stubFor(get(urlEqualTo(resourcePath)).inScenario(scenarioName)
+            .withHeader("Accept", equalTo("application/json"))
+            .whenScenarioStateIs(secondCallState)
+            .willReturn(aResponse()
+                .withFault(Fault.EMPTY_RESPONSE)
+            )
+            .willSetStateTo(thirdCallState)
+        );
+
+        stubFor(get(urlEqualTo(resourcePath)).inScenario(scenarioName)
+            .withHeader("Accept", equalTo("application/json"))
+            .whenScenarioStateIs(thirdCallState)
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(format("{ \"message\": \"%s\" }", forthCallState)))
+            .willSetStateTo(forthCallState)
+        );
+
+        JerseyClientWithRetryBackoffConfiguration clientConfig = new JerseyClientWithRetryBackoffConfiguration();
+        clientConfig.setRetries(3);
+        clientConfig.setRetryBackoffPeriod(Duration.milliseconds(1000));
+        clientConfig.setTimeout(Duration.milliseconds(1000));
+        clientConfig.setConnectionTimeout(Duration.milliseconds(1000));
+        clientConfig.setRetryExceptionNames(Arrays.asList(new String[]{
+            NoHttpResponseException.class.getName(),
+            SocketTimeoutException.class.getName(),
+            SocketException.class.getName()
+        }));
+
+        ClientProvider provider = new ClientProvider(
+            testAppRule.getEnvironment(),
+            clientConfig,
+            true,
+            "multipleErrorRetryWithBackoffTests_forthCallSucceedssClient"
+        );
+        Client client = provider.get();
+
+        WebTarget target = client.target(format("http://localhost:%d%s", wireMockRule.port(), resourcePath));
+        final Invocation.Builder request = target.request();
+        long start = System.currentTimeMillis();
+
+        final Response response = request.accept(MediaType.APPLICATION_JSON).get();
+
+        int status = response.getStatus();
+        long end = System.currentTimeMillis();
+        Scenario scenario = this.getScenario(scenarioName);
+
+        assertEquals(200, status);
+        assertEquals(forthCallState, scenario.getState());
+        assertTrue((end - start) >= getTotalBackoffPeriod(3, clientConfig.getRetryBackoffPeriod()));
+    }
+
+
+    @Test
+    public void emptyResponseRetryWithBackoffTests_secondCallSucceeds() {
+        final String firstCallState = "Call 1 Complete";
+        final String secondCallState = "Call 2 Complete";
+        final String scenarioName = "empty response scenario";
+        final String resourcePath = "/empty-resource";
+
+        stubFor(get(urlEqualTo(resourcePath)).inScenario(scenarioName)
+            .withHeader("Accept", equalTo("application/json"))
+            .whenScenarioStateIs(STARTED)
+            .willSetStateTo(firstCallState)
+            .willReturn(aResponse()
+                .withFault(Fault.EMPTY_RESPONSE)
+            )
+        );
+
+        stubFor(get(urlEqualTo(resourcePath)).inScenario(scenarioName)
+            .withHeader("Accept", equalTo("application/json"))
+            .whenScenarioStateIs(firstCallState)
+            .willSetStateTo(secondCallState)
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(format("{ \"message\": \"%s\" }", secondCallState))
+            )
+        );
+
+        JerseyClientWithRetryBackoffConfiguration clientConfig = new JerseyClientWithRetryBackoffConfiguration();
+        clientConfig.setRetries(3);
+        clientConfig.setRetryBackoffPeriod(Duration.milliseconds(2000));
+        clientConfig.setTimeout(Duration.milliseconds(1000));
+        clientConfig.setConnectionTimeout(Duration.milliseconds(1000));
+        clientConfig.setRetryExceptionNames(Arrays.asList(new String[]{
+                NoHttpResponseException.class.getName()
+        }));
+
+       ClientProvider provider = new ClientProvider(
+            testAppRule.getEnvironment(),
+            clientConfig,
+            true,
+            "emptyResponseRetryWithBackoffTests_secondCallSucceedsClient"
+        );
+        Client client = provider.get();
+
+        WebTarget target = client.target(format("http://localhost:%d%s", wireMockRule.port(), resourcePath));
+
+        final Invocation.Builder request = target.request();
+        long start = System.currentTimeMillis();
+
+        final Response response = request.accept(MediaType.APPLICATION_JSON).get();
+
+        int status = response.getStatus();
+        long end = System.currentTimeMillis();
+
+        assertEquals(200, status);
+        assertEquals(secondCallState, getAllScenarios().get(0).getState());
+        assertTrue((end - start) >= clientConfig.getRetryBackoffPeriod().toMilliseconds());
+    }
+
+    private long getTotalBackoffPeriod(int retries, Duration duration){
+        return ((retries * (retries + 1)) / 2) * duration.toMilliseconds();
+    }
+
+    private Scenario getScenario(String scenarioName) {
+        for( Scenario s: getAllScenarios()) {
+            if (s.getName().equals(scenarioName)) return s;
+        }
+        throw new RuntimeException(format("Scenario not found: {0} ", scenarioName));
+    }
+}

--- a/rest-utils/src/test/java/uk/gov/ida/restclient/TestApplication.java
+++ b/rest-utils/src/test/java/uk/gov/ida/restclient/TestApplication.java
@@ -1,0 +1,12 @@
+package uk.gov.ida.restclient;
+
+import io.dropwizard.Application;
+import io.dropwizard.setup.Environment;
+
+public class TestApplication extends Application<TestApplicationConfig> {
+
+    @Override
+    public void run(TestApplicationConfig configuration, Environment environment) throws Exception {
+
+    }
+}

--- a/rest-utils/src/test/java/uk/gov/ida/restclient/TestApplicationConfig.java
+++ b/rest-utils/src/test/java/uk/gov/ida/restclient/TestApplicationConfig.java
@@ -1,0 +1,6 @@
+package uk.gov.ida.restclient;
+
+import io.dropwizard.Configuration;
+
+public class TestApplicationConfig extends Configuration {
+}

--- a/rest-utils/src/test/java/uk/gov/ida/restclient/TimeoutRequestRetryHandlerTest.java
+++ b/rest-utils/src/test/java/uk/gov/ida/restclient/TimeoutRequestRetryHandlerTest.java
@@ -7,7 +7,6 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.junit.Before;
 import org.junit.Test;
-
 import java.io.IOException;
 
 import static org.junit.Assert.assertFalse;
@@ -42,8 +41,6 @@ public class TimeoutRequestRetryHandlerTest {
 
         assertTrue(expected);
 
-
-        timeoutRequestRetryHandler = new TimeoutRequestRetryHandler(numRetries);
         expected = timeoutRequestRetryHandler.retryRequest(new ConnectTimeoutException(), executionCount, httpContext);
 
         assertFalse(expected);

--- a/rest-utils/src/test/java/uk/gov/ida/restclient/TimeoutRequestRetryWithBackoffHandlerTest.java
+++ b/rest-utils/src/test/java/uk/gov/ida/restclient/TimeoutRequestRetryWithBackoffHandlerTest.java
@@ -1,0 +1,143 @@
+package uk.gov.ida.restclient;
+
+import io.dropwizard.util.Duration;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TimeoutRequestRetryWithBackoffHandlerTest {
+
+    private HttpContext httpContext = new BasicHttpContext();
+
+    @Before
+    public void setup() {
+        httpContext.setAttribute(HttpClientContext.HTTP_REQUEST, new BasicHttpRequest("GET", "http://localhost"));
+    }
+
+    @Test
+    public void should_retry_ConnectTimeoutExceptionByDefault() {
+        final int numRetries = 2;
+
+        TimeoutRequestRetryWithBackoffHandler timeoutRequestRetryHandler = new TimeoutRequestRetryWithBackoffHandler(numRetries,Duration.milliseconds(1000));
+        final boolean expected = timeoutRequestRetryHandler.retryRequest(new ConnectTimeoutException(), 1, httpContext);
+
+        assertTrue(expected);
+    }
+
+    @Test
+    public void should_retry_SocketTimeoutExceptionByDefault() {
+        final int numRetries = 2;
+
+        TimeoutRequestRetryWithBackoffHandler timeoutRequestRetryHandler = new TimeoutRequestRetryWithBackoffHandler(numRetries,Duration.milliseconds(1000));
+        final boolean expected = timeoutRequestRetryHandler.retryRequest(new SocketTimeoutException(), 1, httpContext);
+
+        assertTrue(expected);
+    }
+
+    @Test
+    public void shouldRetryOnSpecifiedExceptionList() {
+        final int numRetries = 2;
+        final List<String> retryExceptionNames = Arrays.asList(new String[]{ "org.apache.http.conn.ConnectTimeoutException", "java.net.SocketTimeoutException", "org.apache.http.NoHttpResponseException"}) ;
+
+        TimeoutRequestRetryWithBackoffHandler timeoutRequestRetryHandler = new TimeoutRequestRetryWithBackoffHandler(numRetries,Duration.milliseconds(1000),retryExceptionNames);
+        boolean expected = timeoutRequestRetryHandler.retryRequest(new SocketTimeoutException(), 1, httpContext);
+        assertTrue(expected);
+
+        expected = timeoutRequestRetryHandler.retryRequest(new ConnectTimeoutException(), 1, httpContext);
+        assertTrue(expected);
+
+        expected = timeoutRequestRetryHandler.retryRequest(new NoHttpResponseException("Response is empty"), 1, httpContext);
+        assertTrue(expected);
+
+        expected = timeoutRequestRetryHandler.retryRequest(new IOException(), 1, httpContext);
+        assertFalse(expected);
+    }
+
+    @Test
+    public void should_only_retry_set_number_of_times() {
+        final int numRetries = 2;
+        final int executionCount = 3;
+
+        TimeoutRequestRetryWithBackoffHandler timeoutRequestRetryHandler = new TimeoutRequestRetryWithBackoffHandler(numRetries,Duration.milliseconds(1000));
+        boolean expected = timeoutRequestRetryHandler.retryRequest(new ConnectTimeoutException(), numRetries, httpContext);
+
+        assertTrue(expected);
+
+
+        timeoutRequestRetryHandler = new TimeoutRequestRetryWithBackoffHandler(numRetries,Duration.milliseconds(1000));
+        expected = timeoutRequestRetryHandler.retryRequest(new ConnectTimeoutException(), executionCount, httpContext);
+
+        assertFalse(expected);
+    }
+
+    @Test
+    public void should_not_be_retry_other_exceptions() {
+        final int numRetries = 2;
+
+        TimeoutRequestRetryWithBackoffHandler timeoutRequestRetryHandler = new TimeoutRequestRetryWithBackoffHandler(numRetries,Duration.milliseconds(1000));
+        final boolean expected = timeoutRequestRetryHandler.retryRequest(new IOException(), 1, httpContext);
+
+        assertFalse(expected);
+    }
+
+    @Test
+    public void firstRetryShouldBackOffForSpecifiedPeriod() {
+        final int numRetries = 3;
+        final Duration backOffPeriod = Duration.milliseconds(1000);
+        final int retryAttempt = 1;
+
+        TimeoutRequestRetryWithBackoffHandler timeoutRequestRetryHandler = new TimeoutRequestRetryWithBackoffHandler(numRetries,backOffPeriod);
+
+        long start = System.currentTimeMillis();
+        final boolean expected = timeoutRequestRetryHandler.retryRequest(new SocketTimeoutException(), retryAttempt, httpContext);
+        long end = System.currentTimeMillis();
+
+        assertTrue(expected);
+        assertTrue((end-start) > retryAttempt * backOffPeriod.toMilliseconds());
+    }
+
+    @Test
+    public void secondRetryShouldBackOffForTwiceSpecifiedPeriod() {
+        final int numRetries = 3;
+        final Duration backOffPeriod = Duration.milliseconds(1000);
+        final int retryAttempt = 2;
+
+        TimeoutRequestRetryWithBackoffHandler timeoutRequestRetryHandler = new TimeoutRequestRetryWithBackoffHandler(numRetries,backOffPeriod);
+
+        long start = System.currentTimeMillis();
+        final boolean expected = timeoutRequestRetryHandler.retryRequest(new SocketTimeoutException(), retryAttempt, httpContext);
+        long end = System.currentTimeMillis();
+
+        assertTrue(expected);
+        assertTrue((end-start) > retryAttempt * backOffPeriod.toMilliseconds());
+    }
+
+    @Test
+    public void thirdRetryShouldBackOffForThriceSpecifiedPeriod() {
+        final int numRetries = 3;
+        final Duration backOffPeriod = Duration.milliseconds(1000);
+        final int retryAttempt = 3;
+
+        TimeoutRequestRetryWithBackoffHandler timeoutRequestRetryHandler = new TimeoutRequestRetryWithBackoffHandler(numRetries,backOffPeriod);
+
+        long start = System.currentTimeMillis();
+        final boolean expected = timeoutRequestRetryHandler.retryRequest(new SocketTimeoutException(), retryAttempt, httpContext);
+        long end = System.currentTimeMillis();
+
+        assertTrue(expected);
+        assertTrue((end-start) > retryAttempt * backOffPeriod.toMilliseconds());
+    }
+}


### PR DESCRIPTION
Create new retry handler that introduces a backoff before retry
Create an extended JerseyClientConfig with backoff parameters included
Update ClientProvider to use appropriate retry handler based on passed parameters

Co-authored-by: Callum Knights <callum.knights@digital.cabinet-office.gov.uk>