### PR TITLE
HUB-142: Allow MSA to retry

### DIFF
--- a/rest-utils/src/main/java/uk/gov/ida/jerseyclient/JerseyClientWithRetryBackoffHandlerConfigurationBuilder.java
+++ b/rest-utils/src/main/java/uk/gov/ida/jerseyclient/JerseyClientWithRetryBackoffHandlerConfigurationBuilder.java
@@ -18,7 +18,7 @@ public class JerseyClientWithRetryBackoffHandlerConfigurationBuilder {
         return new JerseyClientWithRetryBackoffHandlerConfigurationBuilder();
     }
 
-    public JerseyClientConfiguration build() {
+    public JerseyClientWithRetryBackoffConfiguration build() {
         return new TestJerseyClientWithRetryBackoffConfiguration(
             1,
             128,


### PR DESCRIPTION
Correct return type on JerseyClientWithRetryBackoffHandlerConfigurationBuilder.build()