### PR TITLE
HUB-380 update libraries

### DIFF
--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -18,7 +18,7 @@ dependencies {
             "javax.ws.rs:javax.ws.rs-api:2.0.1",
             "uk.gov.ida:dropwizard-logstash:1.3.5-68",
             "org.apache.commons:commons-lang3:3.3.2",
-            "uk.gov.ida:verify-event-emitter:0.0.1-56"
+            "uk.gov.ida:verify-event-emitter:0.0.1-58"
 }
 
 bintray {


### PR DESCRIPTION
Update libraries to include new values for EventDetailsKey enum.

Co-authored-by: Chris Clayson <chris.clayson@digital.cabinet-office.gov.uk>