### PR TITLE
BAU Bump bintray plugin to 1.8.4

### DIFF
--- a/common-utils/build.gradle
+++ b/common-utils/build.gradle
@@ -1,4 +1,4 @@
-plugins { id "com.jfrog.bintray" version "1.8.0" }
+plugins { id "com.jfrog.bintray" version "1.8.4" }
 
 dependencies {
     testCompile 'junit:junit:4.12',

--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -1,4 +1,4 @@
-plugins { id "com.jfrog.bintray" version "1.8.0" }
+plugins { id "com.jfrog.bintray" version "1.8.4" }
 
 dependencies {
     def dependencyVersions = [

--- a/security-utils/build.gradle
+++ b/security-utils/build.gradle
@@ -1,4 +1,4 @@
-plugins { id "com.jfrog.bintray" version "1.8.0" }
+plugins { id "com.jfrog.bintray" version "1.8.4" }
 
 dependencies {
     testCompile 'junit:junit:4.12',


### PR DESCRIPTION
1.8.0 no longer works.