### PR TITLE
BAU Bump dependency versions to mitigate security issues

### DIFF
--- a/common-utils/build.gradle
+++ b/common-utils/build.gradle
@@ -13,7 +13,7 @@ dependencies {
             'org.yaml:snakeyaml:1.12',
             'javax.validation:validation-api:1.1.0.Final',
             'io.dropwizard:dropwizard-logging:1.3.5',
-            'io.dropwizard:dropwizard-configuration:1.3.5'
+            'io.dropwizard:dropwizard-configuration:1.3.9'
 }
 
 bintray {

--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -2,7 +2,7 @@ plugins { id "com.jfrog.bintray" version "1.8.4" }
 
 dependencies {
     def dependencyVersions = [
-            dropwizardVersion:"1.3.5"
+            dropwizardVersion:"1.3.9"
     ]
 
     testCompile "junit:junit:4.12",

--- a/security-utils/build.gradle
+++ b/security-utils/build.gradle
@@ -6,18 +6,9 @@ dependencies {
             'org.mockito:mockito-core:2.7.6'
 
     compile 'javax.inject:javax.inject:1',
-            'io.dropwizard:dropwizard-jackson:1.3.8',
+            'io.dropwizard:dropwizard-jackson:1.3.9',
             'javax.validation:validation-api:1.1.0.Final',
             'commons-codec:commons-codec:1.6'
-    constraints {
-        compile('com.fasterxml.jackson.core:jackson-databind:2.9.8') {
-            because 'dropwizard-jackson:1.3.8 pulls in 2.9.6 which has a high risk vulnerability'
-        }
-        compile('com.google.guava:guava:24.1.1-jre') {
-            because 'dropwizard-jackson:1.3.8 pulls in 24.0 which has a medium risk vulnerability'
-        }
-    }
-
 }
 
 bintray {


### PR DESCRIPTION
The `dropwizard-configuration`, `dropwizard-configuration` and
`dropwizard-core` dependencies all had a transitive dependencies on
`jackson-databind@2.9.6`. This version of jackson-databind is vulnerable
to CVE-2018-19361, CVE-2018-19360, CVE-2018-19362, CVE-2018-14721,
CVE-2018-14719, CVE-2018-14720 and CVE-2018-14718.

Bumping these deps also fixes an issue with a transitive dependency,
`jackson-datatype-jsr310`, that can allow a DoS attack.