### PR TITLE
Add TrustStoreMetrics class

### DIFF
--- a/security-utils/build.gradle
+++ b/security-utils/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 
     compile 'javax.inject:javax.inject:1',
             'io.dropwizard:dropwizard-jackson:1.3.9',
+            'io.prometheus:simpleclient:0.6.0',
             'javax.validation:validation-api:1.1.0.Final',
             'commons-codec:commons-codec:1.6'
 }

--- a/security-utils/src/main/java/uk/gov/ida/common/shared/security/TrustStoreMetrics.java
+++ b/security-utils/src/main/java/uk/gov/ida/common/shared/security/TrustStoreMetrics.java
@@ -1,0 +1,50 @@
+package uk.gov.ida.common.shared.security;
+
+import io.prometheus.client.Gauge;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.X509Certificate;
+import java.util.Enumeration;
+
+/**
+ * <p>A class to register prometheus metrics for expiry dates of certificates in truststores.</p>
+ * <p>The metrics will be in the form:</p>
+ * <pre>
+ * verify_trust_store_certificate_expiry_date{truststore="$name",subject="$subject_dn",serial="$serial"}
+ * </pre>
+ */
+public class TrustStoreMetrics {
+    private Gauge expiryDateGauge;
+
+    /**
+     * Create a new TrustStoreMetrics.  This will automatically register metrics with the default Prometheus
+     * CollectorRegistry.
+     */
+    public TrustStoreMetrics() {
+        expiryDateGauge = Gauge.build("verify_trust_store_certificate_expiry_date", "Expiry date (in unix time milliseconds) of a certificate in a Java truststore")
+                .labelNames("truststore", "subject", "serial")
+                .register();
+    }
+
+    /**
+     * Captures metrics for the certificates in a truststore.
+     * @param name
+     *   A friendly name for the truststore. This will be set as the <code>truststore</code> label on the metric
+     * @param trustStore
+     *   The truststore containing certificates to output metrics for
+     */
+    public void registerTrustStore(String name, KeyStore trustStore) {
+        try {
+            Enumeration<String> aliases = trustStore.aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                X509Certificate certificate = (X509Certificate) trustStore.getCertificate(alias);
+                expiryDateGauge.labels(name, certificate.getSubjectDN().getName(), certificate.getSerialNumber().toString(10))
+                        .set(certificate.getNotAfter().getTime());
+            }
+        } catch (KeyStoreException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
This adds a TrustStoreMetrics class for outputting certificate expiry
dates as Prometheus metrics.  This should make it more visible what
certificates actually exist in a trust store, and when they expire.

An example of how you might use this (in SamlProxyApplication):

    @Override
    public void run(SamlProxyConfiguration configuration, Environment environment) throws Exception {
        // ...

        MetadataResolverConfiguration metadataConfiguration = configuration.getMetadataConfiguration();
        TrustStoreMetrics trustStoreMetrics = new TrustStoreMetrics();
        metadataConfiguration.getHubTrustStore().ifPresent(hubTrustStore -> trustStoreMetrics.registerTrustStore("hub", hubTrustStore));
        metadataConfiguration.getIdpTrustStore().ifPresent(idpTrustStore -> trustStoreMetrics.registerTrustStore("idp", idpTrustStore));

        // ...
    }