### PR TITLE
EID-1448: Upgrade to java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
 language: java
 env:
   - VERIFY_USE_PUBLIC_BINARIES=true
-jdk:
-  - oraclejdk8
-  - oraclejdk9
-  - openjdk8
-matrix:
-  allow_failures:
-  - jdk: oraclejdk9
+jdk: openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ apply plugin: 'java'
 
 idea {
     project {
-        jdkName = '1.8'
-        languageLevel = '1.8'
+        jdkName = '11'
+        languageLevel = '11'
     }
     module {
         //if you love browsing Javadoc

--- a/common-utils/build.gradle
+++ b/common-utils/build.gradle
@@ -3,7 +3,7 @@ plugins { id "com.jfrog.bintray" version "1.8.4" }
 dependencies {
     testCompile 'junit:junit:4.12',
             'org.assertj:assertj-core:1.7.1',
-            'org.mockito:mockito-core:2.7.6'
+            'org.mockito:mockito-core:2.23.4'
 
     compile 'com.google.guava:guava:19.0',
             'commons-codec:commons-codec:1.6',

--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     testCompile "junit:junit:4.12",
             "org.assertj:assertj-core:1.7.1",
-            "org.mockito:mockito-core:2.7.6",
+            "org.mockito:mockito-core:2.23.4",
             "com.github.tomakehurst:wiremock:2.16.0",
             "io.dropwizard:dropwizard-testing:$dependencyVersions.dropwizardVersion"
 
@@ -18,7 +18,8 @@ dependencies {
             "javax.ws.rs:javax.ws.rs-api:2.0.1",
             "uk.gov.ida:dropwizard-logstash:1.3.5-68",
             "org.apache.commons:commons-lang3:3.3.2",
-            "uk.gov.ida:verify-event-emitter:0.0.1-58"
+            "uk.gov.ida:verify-event-emitter:0.0.1-58",
+            "javax.xml.bind:jaxb-api:2.3.1"
 }
 
 bintray {

--- a/rest-utils/src/main/java/uk/gov/ida/resources/VersionInfoResource.java
+++ b/rest-utils/src/main/java/uk/gov/ida/resources/VersionInfoResource.java
@@ -11,7 +11,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -31,10 +30,10 @@ public class VersionInfoResource {
     }
 
     private Attributes getManifest() {
-        URLClassLoader cl = (URLClassLoader) getClass().getClassLoader();
+        ClassLoader cl = getClass().getClassLoader();
         Manifest manifest;
         try {
-            URL url = cl.findResource("META-INF/MANIFEST.MF");
+            URL url = cl.getResource("META-INF/MANIFEST.MF");
             manifest = new Manifest(url.openStream());
         } catch (IOException e) {
             throw Throwables.propagate(e);

--- a/rest-utils/src/test/java/uk/gov/ida/jerseyclient/ErrorHandlingClientTest.java
+++ b/rest-utils/src/test/java/uk/gov/ida/jerseyclient/ErrorHandlingClientTest.java
@@ -91,8 +91,8 @@ public class ErrorHandlingClientTest {
     }
 
     @Test(expected = ApplicationException.class)
-    public void shouldRetryPostRequestIfConfigured() throws Exception {
-        when(webTargetBuilder.post(Entity.json(""))).thenThrow(Exception.class);
+    public void shouldRetryPostRequestIfConfigured() {
+        when(webTargetBuilder.post(Entity.json(""))).thenThrow(ProcessingException.class);
 
         ErrorHandlingClient retryEnabledErrorHandlingClient = new ErrorHandlingClient(client, 2);
         retryEnabledErrorHandlingClient.post(testUri, Collections.emptyMap(), "");
@@ -101,8 +101,8 @@ public class ErrorHandlingClientTest {
     }
 
     @Test(expected = ApplicationException.class)
-    public void shouldRetryGetRequestIfConfigured() throws Exception {
-        when(webTargetBuilder.get()).thenThrow(Exception.class);
+    public void shouldRetryGetRequestIfConfigured() {
+        when(webTargetBuilder.get()).thenThrow(ProcessingException.class);
 
         ErrorHandlingClient retryEnabledErrorHandlingClient = new ErrorHandlingClient(client, 2);
         retryEnabledErrorHandlingClient.get(testUri);

--- a/security-utils/build.gradle
+++ b/security-utils/build.gradle
@@ -3,13 +3,14 @@ plugins { id "com.jfrog.bintray" version "1.8.4" }
 dependencies {
     testCompile 'junit:junit:4.12',
             'org.assertj:assertj-core:1.7.1',
-            'org.mockito:mockito-core:2.7.6'
+            'org.mockito:mockito-core:2.23.4'
 
     compile 'javax.inject:javax.inject:1',
             'io.dropwizard:dropwizard-jackson:1.3.9',
             'io.prometheus:simpleclient:0.6.0',
             'javax.validation:validation-api:1.1.0.Final',
-            'commons-codec:commons-codec:1.6'
+            'commons-codec:commons-codec:1.6',
+            'javax.xml.bind:jaxb-api:2.3.1'
 }
 
 bintray {


### PR DESCRIPTION
- Mockito needed bumping which broke some tests which were using a checked Exception.
- `jaxb-api` was removed in JDK9 and needs importing explicitly if you want to use it.
- Java's class loading strategy changed in Java9 so we had to change the class loader used. [See here for a better explanation](https://blog.codefx.org/java/java-11-migration-guide/#Casting-To-URL-Class-Loader).
