### PR TITLE
EID-1469 Publish directly to artifactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects {
         repositories {
             mavenLocal()
             maven {
-                url "/srv/maven" // change to point to your repo, e.g. http://my.org/repo
+                url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos"
             }
         }
     }


### PR DESCRIPTION
Previously when the build was run on the ci-1 box it was published to a
folder on that box called `/srv/maven`. This folder was synced with
artifactory and the published package would end up it the whitelisted
repos.

We're moving to build this library on concourse where we don't have any
magic folders, so we should publish directly to artifactory.