### PR TITLE
EID-1469 Update publishing URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects {
         repositories {
             mavenLocal()
             maven {
-                url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos"
+                url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
             }
         }
     }


### PR DESCRIPTION
This updates the publishing URL to match other libraries. This allows
the artifact to be PUT and is available in the whitelisted repos.