### PR TITLE
EID-1469 Add creds to publishing repo config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ subprojects {
         repositories {
             mavenLocal()
             maven {
+                credentials {
+                    username "${System.env.ARTIUSER}"
+                    password "${System.env.ARTIPASSWORD}"
+                }
                 url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
             }
         }


### PR DESCRIPTION
Previously the package was just published to a directory on the jenkins
box and needed no creds. Now it's pushing to a remote it does.