### PR TITLE
BAU: enforce back-compatibility with Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: java
 env:
   - VERIFY_USE_PUBLIC_BINARIES=true
-jdk: openjdk11
+jdk:
+  - openjdk11
+  - openjdk8
+  - oraclejdk8
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -9,4 +12,3 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'java'
 idea {
     project {
         jdkName = '11'
-        languageLevel = '11'
+        languageLevel = '8'
     }
     module {
         //if you love browsing Javadoc
@@ -21,6 +21,11 @@ idea {
 }
 
 subprojects {
+    configurations.all {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
+
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'maven-publish'


### PR DESCRIPTION
Ensure that the build will break if Java 9+ features are used. There are still some consumers of the library who have not yet finished migrating to Java 11, alas.

Ideally, we should be able to revert this change in a few months time.