### PR TITLE
BAU Upgrade dropwizard to 1.3.12

### DIFF
--- a/common-utils/build.gradle
+++ b/common-utils/build.gradle
@@ -13,7 +13,7 @@ dependencies {
             'org.yaml:snakeyaml:1.12',
             'javax.validation:validation-api:1.1.0.Final',
             'io.dropwizard:dropwizard-logging:1.3.5',
-            'io.dropwizard:dropwizard-configuration:1.3.9'
+            'io.dropwizard:dropwizard-configuration:1.3.12'
 }
 
 bintray {

--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -2,7 +2,7 @@ plugins { id "com.jfrog.bintray" version "1.8.4" }
 
 dependencies {
     def dependencyVersions = [
-            dropwizardVersion:"1.3.9"
+            dropwizardVersion:"1.3.12"
     ]
 
     testCompile "junit:junit:4.12",

--- a/security-utils/build.gradle
+++ b/security-utils/build.gradle
@@ -6,7 +6,7 @@ dependencies {
             'org.mockito:mockito-core:2.23.4'
 
     compile 'javax.inject:javax.inject:1',
-            'io.dropwizard:dropwizard-jackson:1.3.9',
+            'io.dropwizard:dropwizard-jackson:1.3.12',
             'io.prometheus:simpleclient:0.6.0',
             'javax.validation:validation-api:1.1.0.Final',
             'commons-codec:commons-codec:1.6',


### PR DESCRIPTION
A few vulnerabilities were found in 1.3.9 which were affecting downstream
projects (hub).

[CVE-2019-10247](https://snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-174560)
[CVE-2019-12086](https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-174736)