### PR TITLE
MKaGPO9X: Add enabled flag to TrustStore Config

### DIFF
--- a/rest-utils/src/main/java/uk/gov/ida/truststore/ClientTrustStoreConfiguration.java
+++ b/rest-utils/src/main/java/uk/gov/ida/truststore/ClientTrustStoreConfiguration.java
@@ -9,14 +9,6 @@ import javax.validation.constraints.Size;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ClientTrustStoreConfiguration {
 
-    protected ClientTrustStoreConfiguration() {
-    }
-
-    public ClientTrustStoreConfiguration(String path, String password) {
-        this.path = path;
-        this.password = password;
-    }
-
     @Valid
     @NotNull
     protected String path;
@@ -26,11 +18,32 @@ public class ClientTrustStoreConfiguration {
     @Size(min = 1)
     protected String password;
 
+    @Valid
+    protected boolean enabled = true;
+
+    protected ClientTrustStoreConfiguration() {
+    }
+
+    public ClientTrustStoreConfiguration(String path, String password) {
+        this.path = path;
+        this.password = password;
+    }
+
+    public ClientTrustStoreConfiguration(String path, String password, boolean enabled) {
+        this.path = path;
+        this.password = password;
+        this.enabled = enabled;
+    }
+
     public String getPath() {
         return path;
     }
 
     public String getPassword() {
         return password;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
     }
 }


### PR DESCRIPTION
Add a flag for marking `ClientTrustStoreConfiguration` enabled \ disabled.
This is a feature flag for removing the requirement to validate RP certificates
in the client microservices. Certificate validation will be done on the
Config microservice when required.

co-authored-by: Alan Carter <alan.carter@digital.cabinet-office.gov>