### PR TITLE
OGD-228: Ensure MDC is cleared last

### DIFF
--- a/rest-utils/src/main/java/uk/gov/ida/bundles/LoggingBundle.java
+++ b/rest-utils/src/main/java/uk/gov/ida/bundles/LoggingBundle.java
@@ -25,6 +25,6 @@ public class LoggingBundle implements ConfiguredBundle<ServiceNameConfiguration>
         // Add service-name to context for easy search in kibana
         context.putProperty("service-name", configuration.getServiceName());
         environment.servlets().addFilter("fresh-mdc-filter", ClearMdcAfterRequestFilter.class)
-                .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+                .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), false, "/*");
     }
 }


### PR DESCRIPTION
We want to ensure that the filter that clears the MDC is run last. This is so that previous filters can write log messages with the diagnostic context still set.

Thus, this filter must be matched early. Filters that run first run their post-request clean-up last, which is what we want here

Co-authored-by: Alex Newton <alex.newton@digital.cabinet-office.gov.uk>