### PR TITLE
BAU: Ignore `out` directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ configuration/local
 configuration/vagrant/
 jmeter/*errors*.csv
 *.swp
+/common-utils/out/
+/rest-utils/out/


### PR DESCRIPTION
Ignore `common-utils/out/` and `rest-utils/out/`. These contain build artifacts that should not be added to git.