### PR TITLE
BAU: Stop travis testing with oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 jdk:
   - openjdk11
   - openjdk8
-  - oraclejdk8
 
 before_install:
   - sudo apt-get install jq


### PR DESCRIPTION
Travis's default distribution, 'Xenial', no longer supports testing with oraclejdk8. The options are to use and old distribution, `trusty`, or drop testing with oraclejdk8.

Since `verify-saml-libs` has already been updated to drop oraclejdk8, that is what we will do here.