### PR TITLE
EID-1833: Add get with headers to Json client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jdk:
 
 before_install:
   - sudo apt-get install jq
-  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({content_type, browser_download_url} | select(.content_type | contains("java-archive"))) | .[0].browser_download_url') -o codacy-coverage-reporter-assembly.jar
+  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("codacy-coverage-reporter-assembly")).browser_download_url') -o codacy-coverage-reporter-assembly.jar
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/rest-utils/src/main/java/uk/gov/ida/jerseyclient/ErrorHandlingClient.java
+++ b/rest-utils/src/main/java/uk/gov/ida/jerseyclient/ErrorHandlingClient.java
@@ -35,7 +35,11 @@ public class ErrorHandlingClient {
     }
 
     public Response get(final URI uri) {
-        return get(uri, Collections.<Cookie>emptyList(), Collections.<String, String>emptyMap());
+        return get(uri, Collections.emptyList(), Collections.emptyMap());
+    }
+
+    public Response get(final URI uri, final Map<String, String> headers) {
+        return get(uri, Collections.emptyList(), headers);
     }
 
     public Response get(final URI uri, final List<Cookie> cookies, final Map<String, String> headers) {
@@ -61,7 +65,7 @@ public class ErrorHandlingClient {
     }
 
     public Response post(final URI uri, final Object postBody) {
-        return post(uri, Collections.<String, String>emptyMap(), postBody);
+        return post(uri, Collections.emptyMap(), postBody);
     }
 
     public Response post(final URI uri, final Map<String, String> headers, final Object postBody) {

--- a/rest-utils/src/main/java/uk/gov/ida/jerseyclient/JsonClient.java
+++ b/rest-utils/src/main/java/uk/gov/ida/jerseyclient/JsonClient.java
@@ -34,6 +34,10 @@ public class JsonClient {
         return responseProcessor.getJsonEntity(uri, null, clazz, errorHandlingClient.get(uri));
     }
 
+    public <T> T get(URI uri, Class<T> clazz, Map<String, String> headers) {
+        return responseProcessor.getJsonEntity(uri, null, clazz, errorHandlingClient.get(uri, headers));
+    }
+
     public <T> T get(URI uri, Class<T> clazz, List<Cookie> cookies, Map<String, String> headers) {
         return responseProcessor.getJsonEntity(uri, null, clazz, errorHandlingClient.get(uri, cookies, headers));
     }

--- a/rest-utils/src/test/java/uk/gov/ida/jerseyclient/ErrorHandlingClientTest.java
+++ b/rest-utils/src/test/java/uk/gov/ida/jerseyclient/ErrorHandlingClientTest.java
@@ -54,6 +54,19 @@ public class ErrorHandlingClientTest {
     }
 
     @Test
+    public void getWithHeadersShouldAddHeadersToRequest() {
+        String headerName = "X-Sausages";
+        String headerValue = "Yes please";
+        final Map<String, String> headers = ImmutableMap.of(headerName, headerValue);
+
+        errorHandlingClient.get(testUri, headers);
+
+        verify(webTargetBuilder, times(1)).header(headerName, headerValue);
+        verify(webTargetBuilder, times(1)).get();
+        verify(webTargetBuilder, never()).cookie(any(Cookie.class));
+    }
+
+    @Test
     public void getWithCookiesAndHeaders_shouldAddCookiesAndHeadersToRequest() throws Exception {
         final Cookie cookie = new Cookie("cookie", "monster");
         final List<Cookie> cookies = ImmutableList.of(cookie);

--- a/rest-utils/src/test/java/uk/gov/ida/jerseyclient/JsonClientTest.java
+++ b/rest-utils/src/test/java/uk/gov/ida/jerseyclient/JsonClientTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.jerseyclient;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,6 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
+import java.util.Map;
 
 import static org.mockito.Mockito.*;
 
@@ -56,6 +58,17 @@ public class JsonClientTest {
         jsonClient.get(testUri, String.class);
 
         verify(jsonResponseProcessor, times(1)).getJsonEntity(testUri, null, String.class, clientResponse);
+    }
+
+    @Test
+    public void getWithHeadersShouldPassHeadersToErrorHandlingClient() {
+        String headerName = "X-Sausages";
+        String headerValue = "Yes please";
+        final Map<String, String> headers = ImmutableMap.of(headerName, headerValue);
+
+        jsonClient.get(testUri, String.class, headers);
+
+        verify(errorHandlingClient).get(testUri, headers);
     }
 
     @Test


### PR DESCRIPTION
We want to use the Json client in the proxy-node to get a resource from
a new micro services. We need to be able to pass Istio headers along
with the GET request. This PR extends the `ErrorHandlingClient` to accept
a map of headers to include, without also including any cookies.