### PR TITLE
BAU: fix dropwizard version

### DIFF
--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -16,7 +16,7 @@ dependencies {
             "io.dropwizard:dropwizard-core:$dependencyVersions.dropwizardVersion",
             "io.dropwizard:dropwizard-client:$dependencyVersions.dropwizardVersion",
             "javax.ws.rs:javax.ws.rs-api:2.0.1",
-            "uk.gov.ida:dropwizard-logstash:2.0.2-84",
+            "uk.gov.ida:dropwizard-logstash:1.3.20-85",
             "org.apache.commons:commons-lang3:3.3.2",
             "javax.xml.bind:jaxb-api:2.3.1"
 }


### PR DESCRIPTION
Dropwizard 2.0.2 was causing issues in the proxy node.
Version 1.3.20 we stop this. No reason for using 2.0.+