### PR TITLE
BAU - Enable dependabot for verify-utils-libs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,10 @@ language: java
 env:
   global:
     - VERIFY_USE_PUBLIC_BINARIES=true
-    # GITHUB_PAT
-    - secure: "CwesnXzTCl5UxsCAfmQviTXRFPi2TwPJsxQISf1Iotxe26b4lzAzVa/aTYuW4dy6y3nqyafCZ5EckoU5i8ICYB5+aYZ+/1tn027jGpOVtnWSj3IRF8C0ZV5WIGlzg76Q35FZGoVKFb2XIPyD9MFKsLGAeWU8xDQf6g9YYEY5yrmGQvYUkYWNvWh7uLnCAalfsKK4zvxO4HdZA793b3XgZ6sWk1l0XL6bYHXlCPdKL9DLo/FBozRRXqMD2Agfgb8uyJu7W3kDGI1lTHfBaNCHX6xDVbd0XCOB5Le28MBJTYZk+CqvNlOYdgL7oJIra9M0k9unJFCWcKipQBEHrJygBQMXKEblbRgoJlVnoG1VVdXTyBPKGZmf2Ghf3i6X/TV00HXE7ky/8XvdozFBPFoEV2T4ymWm8GbgN9K+oWv614TvhShO1khq5F+tjLc9sbgYXVaXn61YNWp/hFiOBldK6dZwTADQCt6TYsIMRuF4i6EgrBzs3d/LYYVSMhjtmuhN927ERxvcCrRNsuazJE2FqNGlab5um+NU/p2NmBL/mElzJ3+TIlTiFaW4RiblYC7d8giCjY/9dtRDA7i3KpXs1ppA0vyKTk2C6Pz1Fz5UBMlzCdgcGKTr/lol7B/mdacwqqLor6XmCd83sJXm31vmfS0kCvqdtoQob+nfTONglQM="
-    # CODACY_PROJECT_TOKEN
-    - secure: "KwAinH4pO4zNuSgy0Hkb7eGs46zkd5YjpNoeb8rAckDhHY9MFDpSbmpdnAoQ066SyzDpSVNAAzYDel2RF8MkgId77bZvl6J7Y0Jyr1I4rA4q4xEkYLESZwoVOl0vSzH30rYUxojJHm/L63S6jp4dxkWBXLBL2vpAGr3qXIhQu45RLde4Mn89iaSMJgsdNea5+fb/S7CZJftI0MzYxp3Gszu3Y0gtmbyr0h4/g8TbKDmPXyNmYprMhARpbwAh67O8O30d6EioJvXlWLCP8dooELxcYuL6e5KrTmCpCNiAsNkeZGipxqRY3bL5QKVcoXFGFVur0/OAtsPbLP3sSPUVd5okW3U00ohKOJ6N7A3C0tLZkGYzb/OqkCmAzyYc9cRC/OlTlNVS1tNDnO6cEMmonmwlGL/XR8oUInQwiF4dvw8gxnHg8+Lyr7bW1n5ohI146ewOVAShDPpnooR+Or6EbrvMjtlo0Ot5uyOFNgVnTtvvMEU3dQUgSTHnGIDohdZb6VVQ1VfOeaFNcGJbHLwyxx/IfkV+MSA/8CCz6ZdD6QxcZr88z7NgsvrDL+SdWWTLoAIbzOOHt6vJsXUhYVYy75Tuo+7c+X2jFDkoQOO5T0QRQXpPEL2+DXVrbbViduBoN7Q0uAJzsceDZsDGTHe2EBS08HVxLBBGJapCnDeSikI="
 
 jdk:
   - openjdk8
   - openjdk11
-
-before_install:
-  - sudo apt-get install jq
-  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("codacy-coverage-reporter-assembly")).browser_download_url') -o codacy-coverage-reporter-assembly.jar
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -24,7 +16,3 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-
-after_success:
-  - "./gradlew jacocoRootReport"
-  - java -jar codacy-coverage-reporter-assembly.jar report -l Java -r build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Verify Utils Libraries
 
 [![Build Status](https://travis-ci.org/alphagov/verify-utils-libs.svg?branch=master)](https://travis-ci.org/alphagov/verify-utils-libs)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/fe2fa95be2094f2aabe32a253437194a)](https://www.codacy.com/app/alphagov/verify-utils-libs?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=alphagov/verify-utils-libs&amp;utm_campaign=Badge_Grade)
+
 
 Libraries for performing various utility operations within Verify. These include:
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
 allprojects {
     apply plugin: 'idea'
     apply plugin: 'java'
-    apply plugin: 'jacoco'
     apply plugin: 'signing'
     apply plugin: 'maven-publish'
 }
@@ -129,28 +128,6 @@ subprojects {
     }
 }
 
-task jacocoMerge(type: JacocoMerge) {
-    destinationFile = file("$buildDir/jacoco/allTestCoverage.exec")
-    executionData = project.fileTree(dir: '.', include:'**/build/jacoco/*est.exec')
-    jacocoClasspath = project.files(project.configurations.jacocoAnt)
-}
-
-task jacocoRootReport(type: JacocoReport) {
-    dependsOn jacocoMerge
-
-    additionalSourceDirs files(subprojects.sourceSets.main.allSource.srcDirs)
-    additionalClassDirs files(subprojects.sourceSets.main.output)
-    executionData jacocoMerge.destinationFile
-
-    reports {
-        html.enabled = true
-        xml.enabled = true
-    }
-
-    doFirst {
-        executionData files(executionData.findAll { it.exists() })
-    }
-}
 
 task sonar(dependsOn: [':clean', ':build', 'sonarqube'])
 


### PR DESCRIPTION
- Enable dependabot for verify-utils-libs
- Remove codacy as it has been removed from other verify projects and is not used  