### PR TITLE
BAU build: bump to latest dropwizard version

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.2-open

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,8 @@ subprojects {
         }
     }
 
+    task allDeps(type: DependencyReportTask) {}
+
 
     task sourceJar(type: Jar) {
         from sourceSets.main.allJava

--- a/common-utils/build.gradle
+++ b/common-utils/build.gradle
@@ -10,7 +10,7 @@ dependencies {
             'joda-time:joda-time:2.7',
             'org.yaml:snakeyaml:1.33',
             'javax.validation:validation-api:2.0.1.Final',
-            'io.dropwizard:dropwizard-logging:2.1.2',
-            'io.dropwizard:dropwizard-configuration:2.1.2'
+            'io.dropwizard:dropwizard-logging:2.1.3',
+            'io.dropwizard:dropwizard-configuration:2.1.3'
 }
 

--- a/rest-utils/build.gradle
+++ b/rest-utils/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     def dependencyVersions = [
-            dropwizardVersion:"2.1.2"
+            dropwizardVersion:"2.1.3"
     ]
 
     testCompile "junit:junit:4.13.2",

--- a/security-utils/build.gradle
+++ b/security-utils/build.gradle
@@ -4,7 +4,7 @@ dependencies {
             'org.mockito:mockito-core:2.23.4'
 
     compile 'javax.inject:javax.inject:1',
-            'io.dropwizard:dropwizard-jackson:2.1.2',
+            'io.dropwizard:dropwizard-jackson:2.1.3',
             'io.prometheus:simpleclient:0.16.0',
             'javax.validation:validation-api:2.0.1.Final',
             'commons-codec:commons-codec:1.15',


### PR DESCRIPTION
This sets the dependency of interest to:
````
❯ ./gradlew allDeps | grep "commons-text" | sort | uniq
     \--- org.apache.commons:commons-text:1.10.0
|    \--- org.apache.commons:commons-text:1.10.0
|    |    \--- org.apache.commons:commons-text:1.10.0
````