### PR TITLE
Mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Verify Utils Libraries
 
+> **Verify has Closed**
+>
+>This repository is out of date and has been archived
+
 Libraries for performing various utility operations within Verify. These include:
 
 * Miscellaneous common utilities


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.